### PR TITLE
Support asynchronous validators

### DIFF
--- a/src/angular-meteor-auth.js
+++ b/src/angular-meteor-auth.js
@@ -17,8 +17,9 @@ angular.module(name, [
 .factory('$$Auth', [
   '$Mixer',
   '$log',
+  '$q',
 
-function($Mixer, $log) {
+function($Mixer, $log, $q) {
   const Accounts = (Package['accounts-base'] || {}).Accounts;
 
   if (!Accounts) {
@@ -68,20 +69,26 @@ function($Mixer, $log) {
 
       if (!this.currentUser) return this.$$afterFlush(deferred.reject, errors.required);
 
-      const isValid = validate(this.currentUser);
-      // Resolve the promise if validation has passed
-      if (isValid === true) return this.$$afterFlush(deferred.resolve, this.currentUser);
+      $q.when(validate(this.currentUser)).then(isValid => {
+        // Resolve the promise if validation has passed
+        if (isValid === true) {
+          this.$$afterFlush(deferred.resolve, this.currentUser);
+        }
+        else {
+          return $q.reject(isValid);
+        }
+      }).catch(isValid => {
+        let error;
 
-      let error;
+        if (_.isString(isValid) || isValid instanceof Error) {
+          error = isValid;
+        }
+        else {
+          error = errors.forbidden;
+        }
 
-      if (_.isString(isValid) || isValid instanceof Error) {
-        error = isValid;
-      }
-      else {
-        error = errors.forbidden;
-      }
-
-      return this.$$afterFlush(deferred.reject, error);
+        this.$$afterFlush(deferred.reject, error);
+      });
     });
 
     const promise = deferred.promise;

--- a/tests/integration/auth.spec.js
+++ b/tests/integration/auth.spec.js
@@ -4,10 +4,12 @@ describe('angular-meteor.auth', function() {
 
   var Accounts = Package['accounts-base'].Accounts;
   var $rootScope;
+  var $q;
   var $auth;
 
-  beforeEach(angular.mock.inject(function(_$rootScope_, _$auth_) {
+  beforeEach(angular.mock.inject(function(_$rootScope_, _$q_, _$auth_) {
     $rootScope = _$rootScope_;
+    $q = _$q_;
     $auth = _$auth_;
   }));
 
@@ -170,6 +172,82 @@ describe('angular-meteor.auth', function() {
             done();
           });
 
+        }).onEnd(function() {
+          scope.$$afterFlush('$$throttledDigest');
+        });
+      });
+
+      it('should succeed if validation method asynchronously returns true', function(done) {
+        Accounts.login('tempUser', function() {
+          var spy = jasmine.createSpy().and.returnValue($q.resolve(true));
+
+          scope.$awaitUser(spy).then(function() {
+            expect(Tracker.Computation.prototype.stop).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalled();
+            done();
+          });
+        }).onEnd(function() {
+          scope.$$afterFlush('$$throttledDigest');
+        });
+      });
+
+      it('should return a custom validation error if validation method asynchronously resolves to a string', function(done) {
+        Accounts.login('tempUser', function() {
+          var spy = jasmine.createSpy().and.returnValue($q.resolve('NOT_ALLOWED'));
+
+          scope.$awaitUser(spy).catch(function(err) {
+            expect(Tracker.Computation.prototype.stop).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalled();
+            expect(err).toEqual('NOT_ALLOWED');
+            done();
+          });
+        }).onEnd(function() {
+          scope.$$afterFlush('$$throttledDigest');
+        });
+      });
+
+      it('should return a custom validation error if validation method asynchronously resolves to an error', function(done) {
+        Accounts.login('tempUser', function() {
+          var err = Error();
+          var spy = jasmine.createSpy().and.returnValue($q.resolve(err));
+
+          scope.$awaitUser(spy).catch(function(err) {
+            expect(Tracker.Computation.prototype.stop).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalled();
+            expect(err).toEqual(err);
+            done();
+          });
+        }).onEnd(function() {
+          scope.$$afterFlush('$$throttledDigest');
+        });
+      });
+
+      it('should return a custom validation error if validation method asynchronously rejects to a string', function(done) {
+        Accounts.login('tempUser', function() {
+          var spy = jasmine.createSpy().and.returnValue($q.reject('NOT_ALLOWED'));
+
+          scope.$awaitUser(spy).catch(function(err) {
+            expect(Tracker.Computation.prototype.stop).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalled();
+            expect(err).toEqual('NOT_ALLOWED');
+            done();
+          });
+        }).onEnd(function() {
+          scope.$$afterFlush('$$throttledDigest');
+        });
+      });
+
+      it('should return a custom validation error if validation method asynchronously rejects to an error', function(done) {
+        Accounts.login('tempUser', function() {
+          var err = Error();
+          var spy = jasmine.createSpy().and.returnValue($q.reject(err));
+
+          scope.$awaitUser(spy).catch(function(err) {
+            expect(Tracker.Computation.prototype.stop).toHaveBeenCalled();
+            expect(spy).toHaveBeenCalled();
+            expect(err).toEqual(err);
+            done();
+          });
         }).onEnd(function() {
           scope.$$afterFlush('$$throttledDigest');
         });


### PR DESCRIPTION
In my application, I need asynchronous validators. In this PR, `$awaitUser` now supports asynchronous user validation functions that return a promise. If the validation function returns a promise, the resolved value will be used to determine the user's validity. Also, if it returns a rejected promise, the rejected value will be used as the validation error object. Synchronous validators are still fully supported.
